### PR TITLE
feat: include input msg in error

### DIFF
--- a/node.js
+++ b/node.js
@@ -64,7 +64,7 @@ module.exports = function (RED) {
                 text: "node-red:common.status.error",
               });
               let errorMessage = error.message;
-              node.error(errorMessage, { payload: {} });
+              node.error(errorMessage, msg);
             });
         } else {
           console.error(`Function ${serviceName} does not exist on client.`);


### PR DESCRIPTION
The error object has an empty body, making it impossible to handle errors properly in a `catch` block. For example, in my Slack chatbot flow, I can't notify the user when something goes wrong because the `msg` and `chatId` are missing from the error.