### PR TITLE
Fix file batch cancel and vector store file methods

### DIFF
--- a/src/vector-store-file-batches/methods.js
+++ b/src/vector-store-file-batches/methods.js
@@ -27,7 +27,7 @@ async function retrieveVectorStoreFileBatch(parameters) {
 async function cancelVectorStoreFileBatch(parameters) {
   const openai = new OpenAI(this.clientParams);
   const { vector_store_id, batch_id, ...params } = parameters.payload;
-  const response = await openai.vectorStores.fileBatches.retrieve(
+  const response = await openai.vectorStores.fileBatches.cancel(
     vector_store_id,
     batch_id,
     params

--- a/src/vector-store-files/methods.js
+++ b/src/vector-store-files/methods.js
@@ -26,7 +26,10 @@ async function retrieveVectorStoreFile(parameters) {
 
   const openai = new OpenAI(this.clientParams);
   const { vector_store_id, file_id } = parameters.payload;
-  const response = openai.vectorStores.files.retrieve(vector_store_id, file_id);
+  const response = await openai.vectorStores.files.retrieve(
+    vector_store_id,
+    file_id
+  );
 
   return response;
 }
@@ -36,7 +39,7 @@ async function deleteVectorStoreFile(parameters) {
 
   const openai = new OpenAI(this.clientParams);
   const { vector_store_id, file_id, ...params } = parameters.payload;
-  const response = openai.vectorStores.files.del(
+  const response = await openai.vectorStores.files.del(
     vector_store_id,
     file_id,
     params


### PR DESCRIPTION
## Summary
- fix cancelVectorStoreFileBatch to call the `cancel` endpoint
- ensure retrieve and delete vector store file methods await API promises

## Testing
- `npm run build` *(fails: gulp not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401e46e1d4832bb674bafc65e5b604